### PR TITLE
Merkle Tree construction from elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,21 @@
 version = 3
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
+
+[[package]]
 name = "merkle-tree"
 version = "0.1.0"
+dependencies = [
+ "hex",
+ "hmac-sha256",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hex = "0.4.3"
+hmac-sha256 = "1.1.7"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This project is a Rust implementation of a Merkle Tree.
 
 ## Features
 
-[] A Merkle Tree can be built out of an array.
-[] A Merkle Tree can generate a proof that it contains an element.
-[] A Merkle Tree can verify that a given hash is contained in it.
-[] A Merke Tree can be dynamic, this means that elements can be added once it is built.
+- [ ] A Merkle Tree can be built out of an array.
+
+- [ ] A Merkle Tree can generate a proof that it contains an element.
+
+- [ ] A Merkle Tree can verify that a given hash is contained in it.
+
+- [ ] A Merke Tree can be dynamic, this means that elements can be added once it is built.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This project is a Rust implementation of a Merkle Tree.
 
 ## Usage
+
+## Features
+
+[] A Merkle Tree can be built out of an array.
+[] A Merkle Tree can generate a proof that it contains an element.
+[] A Merkle Tree can verify that a given hash is contained in it.
+[] A Merke Tree can be dynamic, this means that elements can be added once it is built.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This project is a Rust implementation of a Merkle Tree.
 
 ## Usage
 
+## Tests
+
+Just clone and `cargo test`.
+
 ## Features
 
-- [ ] A Merkle Tree can be built out of an array.
+- [x] A Merkle Tree can be built out of an array.
 
 - [ ] A Merkle Tree can generate a proof that it contains an element.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod merkle_tree;

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -14,9 +14,6 @@ impl Default for MerkleTree {
     }
 }
 
-// TODO: type Hash for [u8; 32]
-// TODO: type Level for Vec<[u8; 32]> of even length (duplicates last element if odd)
-
 impl MerkleTree {
     /// Create a new empty MerkleTree instance.
     pub fn new() -> Self {

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -16,30 +16,64 @@ impl MerkleTree {
 
     /// Create a new MerkleTree from the provided items.
     /// Each item should be representable as bytes.
-    pub fn build<T: AsRef<[u8]>>(self, items: &[T]) -> Self {
+    pub fn build<T: AsRef<[u8]>>(&self, items: &[T]) -> Self {
         todo!()
     }
 
+    /// Compute the parent hash for the provided left and right hashes.
+    fn merkle_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+        let concat = [left.as_slice(), right.as_slice()].concat();
+
+        self.hash(&concat)
+    }
+
     /// Hash the provided bytes using SHA-256.
-    fn hash(self, bytes: &[u8]) -> [u8; 32] {
+    /// Returns the hash as a 32 bytes array.
+    fn hash(&self, bytes: &[u8]) -> [u8; 32] {
         Hash::hash(bytes)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::Bytes;
 
     use super::*;
 
     #[test]
     fn test_hash_should_return_sha256_digest() {
         let input = "In a hole in the ground there lived a hobbit.".as_bytes();
-        let expected_hash =
-            hex::decode("38a76005681abd4a4f50a364d472016436f17e79778577ee5825580f06997202")
-                .unwrap();
-        let digest = MerkleTree::new().hash(input).to_vec();
+        let hash = MerkleTree::new().hash(input);
 
-        assert_eq!(digest, expected_hash)
+        assert_eq!(
+            hash.to_vec(),
+            hex::decode("38a76005681abd4a4f50a364d472016436f17e79778577ee5825580f06997202")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_merkle_parent_should_return_hash_of_concated_hashes() {
+        let left_input = "In a hole in the ground ".as_bytes();
+        let left_hash = MerkleTree::new().hash(left_input);
+        assert_eq!(
+            left_hash.to_vec(),
+            hex::decode("0e692eea8afb6955c357130611417c8426b87c5210c6b5206d0caf60a3f069f9")
+                .unwrap()
+        );
+
+        let right_input = "there lived a hobbit.".as_bytes();
+        let right_hash = MerkleTree::new().hash(right_input);
+        assert_eq!(
+            right_hash.to_vec(),
+            hex::decode("fd6914578ce0a0ac2eb1f679a3a8047878c728d6518f48a3f0eb18ee57cc5091")
+                .unwrap()
+        );
+
+        let parent_hash = MerkleTree::new().merkle_parent(&left_hash, &right_hash);
+        assert_eq!(
+            parent_hash.to_vec(),
+            hex::decode("e7dbb63c6671bdf7581e418da8feee175e86adc84adc8e123a30407dd8e730f3")
+                .unwrap()
+        );
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,10 +1,16 @@
 use hmac_sha256::Hash;
 
-pub struct MerkleTree {}
+pub struct MerkleTree {
+    pub root: Option<[u8; 32]>,
+    pub leafs: Vec<[u8; 32]>,
+}
 
 impl Default for MerkleTree {
     fn default() -> Self {
-        Self {}
+        Self {
+            root: None,
+            leafs: Vec::new(),
+        }
     }
 }
 
@@ -12,7 +18,7 @@ impl Default for MerkleTree {
 // TODO: type Level for Vec<[u8; 32]> of even length (duplicates last element if odd)
 
 impl MerkleTree {
-    /// Create a new MerkleTree instance.
+    /// Create a new empty MerkleTree instance.
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -6,14 +6,6 @@ pub struct MerkleTree {
 }
 
 impl MerkleTree {
-    /// Create a new empty MerkleTree instance.
-    pub fn new() -> Self {
-        Self {
-            root: None,
-            leaves: Vec::new(),
-        }
-    }
-
     /// Create a new MerkleTree from the provided items.
     /// Each item should be representable as bytes.
     /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -44,6 +44,17 @@ impl MerkleTree {
             .collect()
     }
 
+    /// Computes the Merkle root hash for the provided leaf hashes.
+    fn merkle_root(&self, leafs: Vec<[u8; 32]>) -> [u8; 32] {
+        let mut level = leafs;
+
+        while level.len() > 1 {
+            level = self.merkle_parent_level(level);
+        }
+
+        level[0]
+    }
+
     /// Hash the provided bytes using SHA-256.
     /// Returns the hash as a 32 bytes array.
     fn hash(&self, bytes: &[u8]) -> [u8; 32] {
@@ -154,6 +165,45 @@ mod tests {
             merkle_tree
                 .merkle_parent(&hashes.clone()[4], &hashes.clone()[4])
                 .to_vec()
+        );
+    }
+
+    #[test]
+    fn test_merkle_root_should_return_root_hash_one_level() {
+        let merkle_tree = MerkleTree::new();
+
+        let hashes = vec![
+            merkle_tree.hash("The Road goes ever on and on,".as_bytes()),
+            merkle_tree.hash("Down from the door where it began.".as_bytes()),
+        ];
+
+        let root_hash = merkle_tree.merkle_root(hashes.clone());
+
+        assert_eq!(
+            root_hash.to_vec(),
+            merkle_tree.merkle_parent(&hashes.clone()[0], &hashes.clone()[1])
+        );
+    }
+
+    #[test]
+    fn test_merkle_root_should_return_root_hash_two_levels() {
+        let merkle_tree = MerkleTree::new();
+
+        let hashes = vec![
+            merkle_tree.hash("One Ring to rule them all, One Ring to find them,".as_bytes()),
+            merkle_tree
+                .hash("One Ring to bring them all and in the darkness bind them.".as_bytes()),
+            merkle_tree.hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
+        ];
+
+        let root_hash = merkle_tree.merkle_root(hashes.clone());
+
+        assert_eq!(
+            root_hash.to_vec(),
+            merkle_tree.merkle_parent(
+                &merkle_tree.merkle_parent(&hashes.clone()[0], &hashes.clone()[1]),
+                &merkle_tree.merkle_parent(&hashes.clone()[2], &hashes.clone()[2]),
+            )
         );
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -18,6 +18,10 @@ impl MerkleTree {
     /// Each item should be representable as bytes.
     /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.
     pub fn build<T: AsRef<[u8]>>(items: &[T]) -> Self {
+        if items.is_empty() {
+            return Self::new();
+        }
+
         let leaves: Vec<[u8; 32]> = items.iter().map(|item| Self::hash(item.as_ref())).collect();
 
         Self {
@@ -191,5 +195,12 @@ mod tests {
                 &MerkleTree::merkle_parent(&hashes.clone()[2], &hashes.clone()[2]),
             )
         );
+    }
+
+    #[test]
+    fn test_build_with_no_items_creates_empty_tree() {
+        let tree = MerkleTree::build(Vec::<&[u8]>::new().as_slice());
+        assert_eq!(tree.root, None);
+        assert_eq!(tree.leaves.len(), 0);
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -25,8 +25,14 @@ impl MerkleTree {
 
     /// Create a new MerkleTree from the provided items.
     /// Each item should be representable as bytes.
+    /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.
     pub fn build<T: AsRef<[u8]>>(&self, items: &[T]) -> Self {
-        todo!()
+        let leafs: Vec<[u8; 32]> = items.iter().map(|item| self.hash(item.as_ref())).collect();
+
+        Self {
+            root: Some(self.merkle_root(leafs.clone())),
+            leafs,
+        }
     }
 
     /// Computes the parent hash for the concatenation of the provided left and right hashes.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -19,4 +19,27 @@ impl MerkleTree {
     pub fn build<T: AsRef<[u8]>>(self, items: &[T]) -> Self {
         todo!()
     }
+
+    /// Hash the provided bytes using SHA-256.
+    fn hash(self, bytes: &[u8]) -> [u8; 32] {
+        Hash::hash(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::Bytes;
+
+    use super::*;
+
+    #[test]
+    fn test_hash_should_return_sha256_digest() {
+        let input = "In a hole in the ground there lived a hobbit.".as_bytes();
+        let expected_hash =
+            hex::decode("38a76005681abd4a4f50a364d472016436f17e79778577ee5825580f06997202")
+                .unwrap();
+        let digest = MerkleTree::new().hash(input).to_vec();
+
+        assert_eq!(digest, expected_hash)
+    }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -35,10 +35,7 @@ impl MerkleTree {
             level.extend(level.last().cloned())
         }
 
-        level
-            .chunks_exact(2)
-            .map(|chunk| Self::merkle_parent(chunk))
-            .collect()
+        level.chunks_exact(2).map(Self::merkle_parent).collect()
     }
 
     /// Computes the Merkle root hash for the provided leaf hashes.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,0 +1,22 @@
+use hmac_sha256::Hash;
+
+pub struct MerkleTree {}
+
+impl Default for MerkleTree {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl MerkleTree {
+    /// Create a new MerkleTree instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new MerkleTree from the provided items.
+    /// Each item should be representable as bytes.
+    pub fn build<T: AsRef<[u8]>>(self, items: &[T]) -> Self {
+        todo!()
+    }
+}

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -5,19 +5,13 @@ pub struct MerkleTree {
     pub leaves: Vec<[u8; 32]>,
 }
 
-impl Default for MerkleTree {
-    fn default() -> Self {
+impl MerkleTree {
+    /// Create a new empty MerkleTree instance.
+    pub fn new() -> Self {
         Self {
             root: None,
             leaves: Vec::new(),
         }
-    }
-}
-
-impl MerkleTree {
-    /// Create a new empty MerkleTree instance.
-    pub fn new() -> Self {
-        Self::default()
     }
 
     /// Create a new MerkleTree from the provided items.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -2,14 +2,14 @@ use hmac_sha256::Hash;
 
 pub struct MerkleTree {
     pub root: Option<[u8; 32]>,
-    pub leafs: Vec<[u8; 32]>,
+    pub leaves: Vec<[u8; 32]>,
 }
 
 impl Default for MerkleTree {
     fn default() -> Self {
         Self {
             root: None,
-            leafs: Vec::new(),
+            leaves: Vec::new(),
         }
     }
 }
@@ -27,11 +27,11 @@ impl MerkleTree {
     /// Each item should be representable as bytes.
     /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.
     pub fn build<T: AsRef<[u8]>>(&self, items: &[T]) -> Self {
-        let leafs: Vec<[u8; 32]> = items.iter().map(|item| self.hash(item.as_ref())).collect();
+        let leaves: Vec<[u8; 32]> = items.iter().map(|item| self.hash(item.as_ref())).collect();
 
         Self {
-            root: Some(self.merkle_root(leafs.clone())),
-            leafs,
+            root: Some(self.merkle_root(leaves.clone())),
+            leaves,
         }
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -17,25 +17,25 @@ impl MerkleTree {
     /// Create a new MerkleTree from the provided items.
     /// Each item should be representable as bytes.
     /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.
-    pub fn build<T: AsRef<[u8]>>(&self, items: &[T]) -> Self {
-        let leaves: Vec<[u8; 32]> = items.iter().map(|item| self.hash(item.as_ref())).collect();
+    pub fn build<T: AsRef<[u8]>>(items: &[T]) -> Self {
+        let leaves: Vec<[u8; 32]> = items.iter().map(|item| Self::hash(item.as_ref())).collect();
 
         Self {
-            root: Some(self.merkle_root(leaves.clone())),
+            root: Some(Self::merkle_root(leaves.clone())),
             leaves,
         }
     }
 
     /// Computes the parent hash for the concatenation of the provided left and right hashes.
-    fn merkle_parent(&self, left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    fn merkle_parent(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
         let concat = [left.as_slice(), right.as_slice()].concat();
 
-        self.hash(&concat)
+        Self::hash(&concat)
     }
 
     /// Creates the parent level for the given level.
     /// If the level has an odd number of hashes, the last hash is duplicated.
-    fn merkle_parent_level(&self, mut level: Vec<[u8; 32]>) -> Vec<[u8; 32]> {
+    fn merkle_parent_level(mut level: Vec<[u8; 32]>) -> Vec<[u8; 32]> {
         // If the number of leafs is odd, duplicate the last leaf.
         if level.len() % 2 == 1 {
             level.extend(level.last().cloned())
@@ -43,16 +43,16 @@ impl MerkleTree {
 
         level
             .chunks_exact(2)
-            .map(|chunk| self.merkle_parent(&chunk[0], &chunk[1]))
+            .map(|chunk| Self::merkle_parent(&chunk[0], &chunk[1]))
             .collect()
     }
 
     /// Computes the Merkle root hash for the provided leaf hashes.
-    fn merkle_root(&self, leafs: Vec<[u8; 32]>) -> [u8; 32] {
+    fn merkle_root(leafs: Vec<[u8; 32]>) -> [u8; 32] {
         let mut level = leafs;
 
         while level.len() > 1 {
-            level = self.merkle_parent_level(level);
+            level = Self::merkle_parent_level(level);
         }
 
         level[0]
@@ -60,7 +60,7 @@ impl MerkleTree {
 
     /// Hash the provided bytes using SHA-256.
     /// Returns the hash as a 32 bytes array.
-    fn hash(&self, bytes: &[u8]) -> [u8; 32] {
+    fn hash(bytes: &[u8]) -> [u8; 32] {
         Hash::hash(bytes)
     }
 }
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_hash_should_return_sha256_digest() {
         let input = "In a hole in the ground there lived a hobbit.".as_bytes();
-        let hash = MerkleTree::new().hash(input);
+        let hash = MerkleTree::hash(input);
 
         assert_eq!(
             hash.to_vec(),
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn test_merkle_parent_should_return_hash_of_concated_hashes() {
         let left_input = "In a hole in the ground ".as_bytes();
-        let left_hash = MerkleTree::new().hash(left_input);
+        let left_hash = MerkleTree::hash(left_input);
         assert_eq!(
             left_hash.to_vec(),
             hex::decode("0e692eea8afb6955c357130611417c8426b87c5210c6b5206d0caf60a3f069f9")
@@ -93,14 +93,14 @@ mod tests {
         );
 
         let right_input = "there lived a hobbit.".as_bytes();
-        let right_hash = MerkleTree::new().hash(right_input);
+        let right_hash = MerkleTree::hash(right_input);
         assert_eq!(
             right_hash.to_vec(),
             hex::decode("fd6914578ce0a0ac2eb1f679a3a8047878c728d6518f48a3f0eb18ee57cc5091")
                 .unwrap()
         );
 
-        let parent_hash = MerkleTree::new().merkle_parent(&left_hash, &right_hash);
+        let parent_hash = MerkleTree::merkle_parent(&left_hash, &right_hash);
         assert_eq!(
             parent_hash.to_vec(),
             hex::decode("e7dbb63c6671bdf7581e418da8feee175e86adc84adc8e123a30407dd8e730f3")
@@ -110,102 +110,85 @@ mod tests {
 
     #[test]
     fn test_even_length_level_should_return_parent_level() {
-        let merkle_tree = MerkleTree::new();
-
         let hashes = vec![
-            merkle_tree.hash("Home is behind, the world ahead,".as_bytes()),
-            merkle_tree.hash("and there are many paths to tread".as_bytes()),
-            merkle_tree.hash("through shadows to the edge of night,".as_bytes()),
-            merkle_tree.hash("until the stars are all alight.".as_bytes()),
+            MerkleTree::hash("Home is behind, the world ahead,".as_bytes()),
+            MerkleTree::hash("and there are many paths to tread".as_bytes()),
+            MerkleTree::hash("through shadows to the edge of night,".as_bytes()),
+            MerkleTree::hash("until the stars are all alight.".as_bytes()),
         ];
 
-        let parent_level = merkle_tree.merkle_parent_level(hashes.clone());
+        let parent_level = MerkleTree::merkle_parent_level(hashes.clone());
 
         assert_eq!(parent_level.len(), 2);
         assert_eq!(
             parent_level[0].to_vec(),
-            merkle_tree
-                .merkle_parent(&hashes.clone()[0], &hashes.clone()[1])
-                .to_vec()
+            MerkleTree::merkle_parent(&hashes.clone()[0], &hashes.clone()[1]).to_vec()
         );
         assert_eq!(
             parent_level[1].to_vec(),
-            merkle_tree
-                .merkle_parent(&hashes.clone()[2], &hashes.clone()[3])
-                .to_vec()
+            MerkleTree::merkle_parent(&hashes.clone()[2], &hashes.clone()[3]).to_vec()
         );
     }
 
     #[test]
     fn test_odd_length_level_should_return_parent_level() {
-        let merkle_tree = MerkleTree::new();
-
         let hashes = vec![
-            merkle_tree.hash("One ring to rule them all,".as_bytes()),
-            merkle_tree.hash("One ring to find them,".as_bytes()),
-            merkle_tree.hash("One ring to bring them all,".as_bytes()),
-            merkle_tree.hash("and in the darkness bind them.".as_bytes()),
-            merkle_tree.hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
+            MerkleTree::hash("One ring to rule them all,".as_bytes()),
+            MerkleTree::hash("One ring to find them,".as_bytes()),
+            MerkleTree::hash("One ring to bring them all,".as_bytes()),
+            MerkleTree::hash("and in the darkness bind them.".as_bytes()),
+            MerkleTree::hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
         ];
 
-        let parent_level = merkle_tree.merkle_parent_level(hashes.clone());
+        let parent_level = MerkleTree::merkle_parent_level(hashes.clone());
 
         assert_eq!(parent_level.len(), 3);
         assert_eq!(
             parent_level[0].to_vec(),
-            merkle_tree
-                .merkle_parent(&hashes.clone()[0], &hashes.clone()[1])
-                .to_vec()
+            MerkleTree::merkle_parent(&hashes.clone()[0], &hashes.clone()[1]).to_vec()
         );
         assert_eq!(
             parent_level[1].to_vec(),
-            merkle_tree
-                .merkle_parent(&hashes.clone()[2], &hashes.clone()[3])
-                .to_vec()
+            MerkleTree::merkle_parent(&hashes.clone()[2], &hashes.clone()[3]).to_vec()
         );
         assert_eq!(
             parent_level[2].to_vec(),
-            merkle_tree
-                .merkle_parent(&hashes.clone()[4], &hashes.clone()[4])
-                .to_vec()
+            MerkleTree::merkle_parent(&hashes.clone()[4], &hashes.clone()[4]).to_vec()
         );
     }
 
     #[test]
     fn test_merkle_root_should_return_root_hash_one_level() {
-        let merkle_tree = MerkleTree::new();
-
         let hashes = vec![
-            merkle_tree.hash("The Road goes ever on and on,".as_bytes()),
-            merkle_tree.hash("Down from the door where it began.".as_bytes()),
+            MerkleTree::hash("The Road goes ever on and on,".as_bytes()),
+            MerkleTree::hash("Down from the door where it began.".as_bytes()),
         ];
 
-        let root_hash = merkle_tree.merkle_root(hashes.clone());
+        let root_hash = MerkleTree::merkle_root(hashes.clone());
 
         assert_eq!(
             root_hash.to_vec(),
-            merkle_tree.merkle_parent(&hashes.clone()[0], &hashes.clone()[1])
+            MerkleTree::merkle_parent(&hashes.clone()[0], &hashes.clone()[1])
         );
     }
 
     #[test]
     fn test_merkle_root_should_return_root_hash_two_levels() {
-        let merkle_tree = MerkleTree::new();
-
         let hashes = vec![
-            merkle_tree.hash("One Ring to rule them all, One Ring to find them,".as_bytes()),
-            merkle_tree
-                .hash("One Ring to bring them all and in the darkness bind them.".as_bytes()),
-            merkle_tree.hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
+            MerkleTree::hash("One Ring to rule them all, One Ring to find them,".as_bytes()),
+            MerkleTree::hash(
+                "One Ring to bring them all and in the darkness bind them.".as_bytes(),
+            ),
+            MerkleTree::hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
         ];
 
-        let root_hash = merkle_tree.merkle_root(hashes.clone());
+        let root_hash = MerkleTree::merkle_root(hashes.clone());
 
         assert_eq!(
             root_hash.to_vec(),
-            merkle_tree.merkle_parent(
-                &merkle_tree.merkle_parent(&hashes.clone()[0], &hashes.clone()[1]),
-                &merkle_tree.merkle_parent(&hashes.clone()[2], &hashes.clone()[2]),
+            MerkleTree::merkle_parent(
+                &MerkleTree::merkle_parent(&hashes.clone()[0], &hashes.clone()[1]),
+                &MerkleTree::merkle_parent(&hashes.clone()[2], &hashes.clone()[2]),
             )
         );
     }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -17,17 +17,17 @@ impl MerkleTree {
     /// Create a new MerkleTree from the provided items.
     /// Each item should be representable as bytes.
     /// It returns a `MerkleTree` instance with the leaf hashes and the Merkle root.
-    pub fn build<T: AsRef<[u8]>>(items: &[T]) -> Self {
+    pub fn build<T: AsRef<[u8]>>(items: &[T]) -> Option<Self> {
         if items.is_empty() {
-            return Self::new();
+            return None;
         }
 
         let leaves: Vec<[u8; 32]> = items.iter().map(|item| Self::hash(item.as_ref())).collect();
 
-        Self {
+        Some(Self {
             root: Some(Self::merkle_root(leaves.clone())),
             leaves,
-        }
+        })
     }
 
     /// Computes the parent hash for the concatenation of the children hashes.
@@ -193,9 +193,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_with_no_items_creates_empty_tree() {
+    fn test_build_with_no_items_returns_none() {
         let tree = MerkleTree::build(Vec::<&[u8]>::new().as_slice());
-        assert_eq!(tree.root, None);
-        assert_eq!(tree.leaves.len(), 0);
+        assert!(tree.is_none());
     }
 }


### PR DESCRIPTION
Provides the base structure and implementation of the Merkle Tree. Basic methods for hashing and computation of the Merkle root have been implemented and tested. This PR provides the ability to create a new Merkle Tree from a list of elements. The resulting Merkle Tree contains the leaves and the Merkle root.