### PR TITLE
Proof of inclusion and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Just clone and `cargo test`.
 
 - [x] A Merkle Tree can generate a proof that it contains an element.
 
+- [x] A Merkle Tree can validate that the proof for a given hash is correct.
+
 - [ ] A Merkle Tree can verify that a given hash is contained in it.
 
 - [ ] A Merke Tree can be dynamic, this means that elements can be added once it is built.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Just clone and `cargo test`.
 
 - [x] A Merkle Tree can validate that the proof for a given hash is correct.
 
-- [ ] A Merkle Tree can verify that a given hash is contained in it.
+- [x] A Merkle Tree can verify that a given hash is contained in it.
 
 - [ ] A Merke Tree can be dynamic, this means that elements can be added once it is built.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just clone and `cargo test`.
 
 - [x] A Merkle Tree can be built out of an array.
 
-- [ ] A Merkle Tree can generate a proof that it contains an element.
+- [x] A Merkle Tree can generate a proof that it contains an element.
 
 - [ ] A Merkle Tree can verify that a given hash is contained in it.
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -33,7 +33,9 @@ impl MerkleTree {
 
     /// Computes the parent hash for the concatenation of the children hashes.
     fn merkle_parent(children: &[[u8; 32]]) -> [u8; 32] {
-        Self::hash(children.as_flattened())
+        let mut children_vector = children.to_vec();
+        children_vector.sort();
+        Self::hash(children_vector.as_flattened())
     }
 
     /// Creates the parent level for the given level.

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -115,6 +115,10 @@ impl MerkleTree {
 
         validation_root == self.root()
     }
+
+    pub fn contains_hash(&self, hash: &[u8; 32]) -> bool {
+        self.levels[0].iter().any(|h| h == hash)
+    }
 }
 
 #[cfg(test)]
@@ -388,5 +392,33 @@ mod tests {
         let proof = tree.proof_of_inclusion(&hash).unwrap();
 
         assert!(tree.validate_proof(&hash, &proof));
+    }
+
+    #[test]
+    fn test_hash_not_included_returns_false() {
+        let items = vec![
+            "Home is behind, the world ahead, ",
+            "and there are many paths to tread.",
+        ];
+
+        let tree = MerkleTree::build(&items).unwrap();
+
+        let hash = MerkleTree::hash("Fly, you fools!".as_bytes());
+
+        assert!(!tree.contains_hash(&hash));
+    }
+
+    #[test]
+    fn test_hash_included_returns_true() {
+        let items = vec![
+            "Home is behind, the world ahead, ",
+            "and there are many paths to tread.",
+        ];
+
+        let tree = MerkleTree::build(&items).unwrap();
+
+        let hash = MerkleTree::hash(items[1].as_bytes());
+
+        assert!(tree.contains_hash(&hash));
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,8 +1,7 @@
 use hmac_sha256::Hash;
 
 pub struct MerkleTree {
-    pub root: Option<[u8; 32]>,
-    pub leaves: Vec<[u8; 32]>,
+    levels: Vec<Vec<[u8; 32]>>,
 }
 
 impl MerkleTree {
@@ -14,12 +13,22 @@ impl MerkleTree {
             return None;
         }
 
-        let leaves: Vec<[u8; 32]> = items.iter().map(|item| Self::hash(item.as_ref())).collect();
+        let total_height = Self::tree_height(items.len());
 
-        Some(Self {
-            root: Some(Self::merkle_root(leaves.clone())),
-            leaves,
-        })
+        let mut levels = Vec::with_capacity(total_height + 1);
+
+        let leaves: Vec<[u8; 32]> = items.iter().map(|item| Self::hash(item.as_ref())).collect();
+        levels.push(leaves);
+
+        while let Some(level) = Self::merkle_parent_level(levels.last().unwrap()) {
+            levels.push(level);
+        }
+
+        Some(Self { levels })
+    }
+
+    fn tree_height(items: usize) -> usize {
+        (items as f64).log2().ceil() as usize
     }
 
     /// Computes the parent hash for the concatenation of the children hashes.
@@ -29,24 +38,30 @@ impl MerkleTree {
 
     /// Creates the parent level for the given level.
     /// If the level has an odd number of hashes, the last hash is duplicated.
-    fn merkle_parent_level(mut level: Vec<[u8; 32]>) -> Vec<[u8; 32]> {
-        // If the number of leafs is odd, duplicate the last leaf.
-        if level.len() % 2 == 1 {
-            level.extend(level.last().cloned())
+    fn merkle_parent_level(level: &Vec<[u8; 32]>) -> Option<Vec<[u8; 32]>> {
+        // Is root, return None.
+        if level.len() == 1 {
+            return None;
         }
 
-        level.chunks_exact(2).map(Self::merkle_parent).collect()
+        // If the number of leafs is odd, duplicate the last leaf.
+        let mut parent_level = level.clone();
+
+        if level.len() % 2 == 1 {
+            parent_level.extend(parent_level.last().cloned())
+        }
+
+        Some(
+            parent_level
+                .chunks_exact(2)
+                .map(Self::merkle_parent)
+                .collect(),
+        )
     }
 
     /// Computes the Merkle root hash for the provided leaf hashes.
-    fn merkle_root(leafs: Vec<[u8; 32]>) -> [u8; 32] {
-        let mut level = leafs;
-
-        while level.len() > 1 {
-            level = Self::merkle_parent_level(level);
-        }
-
-        level[0]
+    pub fn root(&self) -> [u8; 32] {
+        self.levels.last().unwrap().first().unwrap().clone()
     }
 
     /// Hash the provided bytes using SHA-256.
@@ -63,8 +78,8 @@ mod tests {
 
     #[test]
     fn test_hash_should_return_sha256_digest() {
-        let input = "In a hole in the ground there lived a hobbit.".as_bytes();
-        let hash = MerkleTree::hash(input);
+        let input = "In a hole in the ground there lived a hobbit.";
+        let hash = MerkleTree::hash(input.as_bytes());
 
         assert_eq!(
             hash.to_vec(),
@@ -75,16 +90,16 @@ mod tests {
 
     #[test]
     fn test_merkle_parent_should_return_hash_of_concated_hashes() {
-        let left_input = "In a hole in the ground ".as_bytes();
-        let left_hash = MerkleTree::hash(left_input);
+        let left_input = "In a hole in the ground ";
+        let left_hash = MerkleTree::hash(left_input.as_bytes());
         assert_eq!(
             left_hash.to_vec(),
             hex::decode("0e692eea8afb6955c357130611417c8426b87c5210c6b5206d0caf60a3f069f9")
                 .unwrap()
         );
 
-        let right_input = "there lived a hobbit.".as_bytes();
-        let right_hash = MerkleTree::hash(right_input);
+        let right_input = "there lived a hobbit.";
+        let right_hash = MerkleTree::hash(right_input.as_bytes());
         assert_eq!(
             right_hash.to_vec(),
             hex::decode("fd6914578ce0a0ac2eb1f679a3a8047878c728d6518f48a3f0eb18ee57cc5091")
@@ -108,15 +123,16 @@ mod tests {
             MerkleTree::hash("until the stars are all alight.".as_bytes()),
         ];
 
-        let parent_level = MerkleTree::merkle_parent_level(hashes.clone());
+        let parent_level = MerkleTree::merkle_parent_level(&hashes);
 
-        assert_eq!(parent_level.len(), 2);
+        assert!(parent_level.is_some());
+        assert_eq!(parent_level.clone().unwrap().len(), 2);
         assert_eq!(
-            parent_level[0].to_vec(),
+            parent_level.clone().unwrap()[0].to_vec(),
             MerkleTree::merkle_parent(&[hashes[0], hashes[1]]).to_vec()
         );
         assert_eq!(
-            parent_level[1].to_vec(),
+            parent_level.clone().unwrap()[1].to_vec(),
             MerkleTree::merkle_parent(&[hashes[2], hashes[3]]).to_vec()
         );
     }
@@ -131,46 +147,55 @@ mod tests {
             MerkleTree::hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
         ];
 
-        let parent_level = MerkleTree::merkle_parent_level(hashes.clone());
+        let parent_level = MerkleTree::merkle_parent_level(&hashes);
 
-        assert_eq!(parent_level.len(), 3);
+        assert_eq!(parent_level.clone().unwrap().len(), 3);
         assert_eq!(
-            parent_level[0].to_vec(),
+            parent_level.clone().unwrap()[0].to_vec(),
             MerkleTree::merkle_parent(&[hashes[0], hashes[1]]).to_vec()
         );
         assert_eq!(
-            parent_level[1].to_vec(),
+            parent_level.clone().unwrap()[1].to_vec(),
             MerkleTree::merkle_parent(&[hashes[2], hashes[3]]).to_vec()
         );
         assert_eq!(
-            parent_level[2].to_vec(),
+            parent_level.clone().unwrap()[2].to_vec(),
             MerkleTree::merkle_parent(&[hashes[4], hashes[4]]).to_vec()
         );
     }
 
     #[test]
     fn test_merkle_root_should_return_root_hash_one_level() {
-        let hashes = vec![
-            MerkleTree::hash("The Road goes ever on and on,".as_bytes()),
-            MerkleTree::hash("Down from the door where it began.".as_bytes()),
+        let items = vec![
+            "The Road goes ever on and on,",
+            "Down from the door where it began.",
         ];
 
-        let root_hash = MerkleTree::merkle_root(hashes.clone());
+        let hashes = vec![
+            MerkleTree::hash(items[0].as_bytes()),
+            MerkleTree::hash(items[1].as_bytes()),
+        ];
+
+        let root_hash = MerkleTree::build(&items).unwrap().root();
 
         assert_eq!(root_hash.to_vec(), MerkleTree::merkle_parent(&hashes));
     }
 
     #[test]
     fn test_merkle_root_should_return_root_hash_two_levels() {
-        let hashes = vec![
-            MerkleTree::hash("One Ring to rule them all, One Ring to find them,".as_bytes()),
-            MerkleTree::hash(
-                "One Ring to bring them all and in the darkness bind them.".as_bytes(),
-            ),
-            MerkleTree::hash("In the Land of Mordor where the Shadows lie.".as_bytes()),
+        let items = vec![
+            "One Ring to rule them all, One Ring to find them,",
+            "One Ring to bring them all and in the darkness bind them.",
+            "In the Land of Mordor where the Shadows lie.",
         ];
 
-        let root_hash = MerkleTree::merkle_root(hashes.clone());
+        let hashes = vec![
+            MerkleTree::hash(items[0].as_bytes()),
+            MerkleTree::hash(items[1].as_bytes()),
+            MerkleTree::hash(items[2].as_bytes()),
+        ];
+
+        let root_hash = MerkleTree::build(&items).unwrap().root();
 
         assert_eq!(
             root_hash.to_vec(),
@@ -179,6 +204,49 @@ mod tests {
                 MerkleTree::merkle_parent(&[hashes[2], hashes[2]])
             ])
         );
+    }
+
+    #[test]
+    fn test_build_merkle_tree() {
+        let items = vec![
+            "One Ring to rule them all,",
+            "One Ring to find them,",
+            "One Ring to bring them all",
+            "and in the darkness bind them.",
+            "In the Land of Mordor where the Shadows lie.",
+        ];
+
+        let hashes = vec![
+            MerkleTree::hash(items[0].as_bytes()),
+            MerkleTree::hash(items[1].as_bytes()),
+            MerkleTree::hash(items[2].as_bytes()),
+            MerkleTree::hash(items[3].as_bytes()),
+            MerkleTree::hash(items[4].as_bytes()),
+        ];
+
+        let tree = MerkleTree::build(&items).unwrap();
+
+        assert_eq!(tree.levels.len(), 4);
+        // Check length of each level.
+        assert_eq!(tree.levels[0].len(), 5);
+        assert_eq!(tree.levels[1].len(), 3);
+        assert_eq!(tree.levels[2].len(), 2);
+        assert_eq!(tree.levels[3].len(), 1);
+
+        assert_eq!(tree.levels[0], hashes);
+        assert_eq!(
+            tree.levels[1],
+            MerkleTree::merkle_parent_level(&hashes).unwrap()
+        );
+        assert_eq!(
+            tree.levels[2],
+            MerkleTree::merkle_parent_level(&tree.levels[1]).unwrap()
+        );
+        assert_eq!(
+            tree.levels[3],
+            MerkleTree::merkle_parent_level(&tree.levels[2]).unwrap()
+        );
+        assert_eq!(tree.root().to_vec(), tree.levels[3][0].to_vec());
     }
 
     #[test]


### PR DESCRIPTION
The Merkle Tree is now able to generate a proof of inclusion for a given hash. Said proof can be validated, given the hash to validate and the proof.